### PR TITLE
Use item Content as e-mail body if Description is empty

### DIFF
--- a/mail.go
+++ b/mail.go
@@ -76,7 +76,11 @@ func createEmail(feedName string, feedTitle string, item *gofeed.Item, date time
 	email.Date = date
 	email.setUserAgent(conf)
 	email.ItemURI = item.Link
-	email.Body = item.Description
+	if item.Description == "" {
+		email.Body = item.Content
+	} else {
+		email.Body = item.Description
+	}
 	return email
 }
 


### PR DESCRIPTION
Some Atom feeds do not have a summary (maps to Item.Description in the
parser). If that is the case, set the e-mail body to Item.Content.

For RSS, Item.Content will always be empty but using it when
Item.Description is also empty has no observable effect.