### PR TITLE
Use temp file and rename when saving config

### DIFF
--- a/config/import.go
+++ b/config/import.go
@@ -91,6 +91,5 @@ func ImportCfg(args []string) error {
 		}
 		conf.Accounts[name] = AccountConfig{URI: uri}
 	}
-	// TODO: Use ioutil.TempFile and os.Rename to make this atomic
-	return conf.write(conf.path)
+	return conf.save()
 }


### PR DESCRIPTION
Adds a new private save method for writing the new configuration to a
temp file then use rename to atomically overwrite the old
configuration.