### PR TITLE
Add list-id header and use RSS entry author to e-mail

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -32,16 +32,17 @@ func (cfg AccountConfig) String() string {
 }
 
 type GrueConfig struct {
-	path        string
-	Recipient   string
-	FromAddress string
-	NameFormat  string
-	UserAgent   string
-	SmtpUser    *string
-	SmtpPass    *string
-	SmtpServer  *string
-	LogLevel    *string
-	Accounts    map[string]AccountConfig
+	path         string
+	Recipient    string
+	FromAddress  string
+	NameFormat   string
+	ListIdFormat string
+	UserAgent    string
+	SmtpUser     *string
+	SmtpPass     *string
+	SmtpServer   *string
+	LogLevel     *string
+	Accounts     map[string]AccountConfig
 }
 
 func (conf *GrueConfig) Lock() error {

--- a/grue.go
+++ b/grue.go
@@ -71,7 +71,7 @@ func list(args []string, conf *config.GrueConfig) error {
 	}
 	if len(listCmd.Args()) == 0 {
 		var keys []string
-		for k, _ := range conf.Accounts {
+		for k := range conf.Accounts {
 			keys = append(keys, k)
 		}
 		sort.Strings(keys)

--- a/mail.go
+++ b/mail.go
@@ -2,14 +2,15 @@ package main
 
 import (
 	"fmt"
-	"github.com/c-14/grue/config"
-	"github.com/jaytaylor/html2text"
-	"github.com/mmcdole/gofeed"
-	"gopkg.in/gomail.v2"
 	"io"
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/c-14/grue/config"
+	"github.com/jaytaylor/html2text"
+	"github.com/mmcdole/gofeed"
+	"gopkg.in/gomail.v2"
 )
 
 type Email struct {

--- a/rss.go
+++ b/rss.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/c-14/grue/config"
-	"github.com/mmcdole/gofeed"
 	"math"
 	"os"
 	"time"
+
+	"github.com/c-14/grue/config"
+	"github.com/mmcdole/gofeed"
 )
 
 type FeedFetcher struct {

--- a/rss.go
+++ b/rss.go
@@ -99,7 +99,7 @@ func fetchFeed(fp FeedFetcher, feedName string, account *RSSFeed, config *config
 			_, exists := guids[item.GUID]
 			date, newer := hasNewerDate(item, account.LastFetched)
 			if !exists || (item.GUID == "" && newer == DateNewer) {
-				e := createEmail(feedName, feed.Title, item, date, account.config, config)
+				e := createEmail(feedName, feed, item, date, account.config, config)
 				err = e.Send()
 			}
 			if err == nil {


### PR DESCRIPTION
Adds a configuration item, ListIdFormat, to add and set the List-Id e-mail header in generated e-mails.

Also add support for `{author}` in NameFormat configuration option which will use the RSS item or feed author if it is present.

Finally, a couple of code clean ups.